### PR TITLE
 Remove baseUri from postman adapter environments

### DIFF
--- a/postman/xs2a gateway (adorsys-integ) .postman_environment.json
+++ b/postman/xs2a gateway (adorsys-integ) .postman_environment.json
@@ -1,16 +1,10 @@
 {
-	"id": "b14ba9cd-40d2-452f-bba3-f6fc37df7b1c",
-	"name": "local xs2a gateway (sparkasse)",
+	"id": "4cd438f5-9b59-4546-8f1d-47a2361b6f9b",
+	"name": "xs2a gateway (adorsys-integ) ",
 	"values": [
 		{
-			"key": "baseUri",
-			"value": "http://localhost:8081",
-			"description": "",
-			"enabled": true
-		},
-		{
 			"key": "bankCode",
-			"value": "99999999",
+			"value": "adorsys-integ",
 			"description": "",
 			"enabled": true
 		},
@@ -22,19 +16,19 @@
 		},
 		{
 			"key": "psuId",
-			"value": "chipTAN",
+			"value": "anton.brueckner",
 			"description": "",
 			"enabled": true
 		},
 		{
 			"key": "iban",
-			"value": "DE86999999990000001000",
+			"value": "DE80760700240271232400",
 			"description": "",
 			"enabled": true
 		},
 		{
 			"key": "password",
-			"value": "okok1",
+			"value": "12345",
 			"description": "",
 			"enabled": true
 		},
@@ -52,6 +46,6 @@
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2019-04-18T11:01:03.986Z",
+	"_postman_exported_at": "2019-04-24T10:14:45.408Z",
 	"_postman_exported_using": "Postman/7.0.7"
 }

--- a/postman/xs2a gateway (consors-bank).postman_environment.json
+++ b/postman/xs2a gateway (consors-bank).postman_environment.json
@@ -1,16 +1,10 @@
 {
-	"id": "dd312e0d-66c1-4da0-aa17-7b2a54931d20",
-	"name": "local xs2a gateway (verlag)",
+	"id": "41410be2-b4a5-4929-a781-4a7b6b9f501b",
+	"name": "xs2a gateway (consors-bank)",
 	"values": [
 		{
-			"key": "baseUri",
-			"value": "http://localhost:8081",
-			"description": "",
-			"enabled": true
-		},
-		{
 			"key": "bankCode",
-			"value": "25040090",
+			"value": "76030080",
 			"description": "",
 			"enabled": true
 		},
@@ -22,36 +16,42 @@
 		},
 		{
 			"key": "psuId",
-			"value": "psuId-test",
+			"value": "PSU-Successful",
 			"description": "",
 			"enabled": true
 		},
 		{
 			"key": "iban",
-			"value": "DE51250400903312345678",
+			"value": "DE60760300800500123456",
 			"description": "",
 			"enabled": true
 		},
 		{
 			"key": "password",
-			"value": "12456",
+			"value": "",
 			"description": "",
 			"enabled": true
 		},
 		{
 			"key": "authenticationMethodId",
-			"value": "901",
-			"description": "SMS-TAN",
+			"value": "",
+			"description": "",
 			"enabled": true
 		},
 		{
 			"key": "scaAuthenticationData",
-			"value": "12456",
+			"value": "",
+			"description": "",
+			"enabled": true
+		},
+		{
+			"key": "adapter",
+			"value": "consors-bank",
 			"description": "",
 			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2019-04-18T11:01:03.986Z",
+	"_postman_exported_at": "2019-04-24T10:10:28.388Z",
 	"_postman_exported_using": "Postman/7.0.7"
 }

--- a/postman/xs2a gateway (dab-bank).postman_environment.json
+++ b/postman/xs2a gateway (dab-bank).postman_environment.json
@@ -1,16 +1,10 @@
 {
-	"id": "55847cdb-3350-4d33-b3a5-812b0d2e746f",
-	"name": "local xs2a gateway (adorsys-integ) ",
+	"id": "5602fe8f-eb09-41e2-9f4b-c3b091766e2d",
+	"name": "xs2a gateway (dab-bank)",
 	"values": [
 		{
-			"key": "baseUri",
-			"value": "http://localhost:8081",
-			"description": "",
-			"enabled": true
-		},
-		{
 			"key": "bankCode",
-			"value": "adorsys-integ",
+			"value": "70120400",
 			"description": "",
 			"enabled": true
 		},
@@ -22,36 +16,42 @@
 		},
 		{
 			"key": "psuId",
-			"value": "anton.brueckner",
+			"value": "PSU-Successful",
 			"description": "",
 			"enabled": true
 		},
 		{
 			"key": "iban",
-			"value": "DE80760700240271232400",
+			"value": "DE74701204003326455007",
 			"description": "",
 			"enabled": true
 		},
 		{
 			"key": "password",
-			"value": "12345",
+			"value": "",
 			"description": "",
 			"enabled": true
 		},
 		{
 			"key": "authenticationMethodId",
-			"value": "OPTICAL",
+			"value": "",
 			"description": "",
 			"enabled": true
 		},
 		{
 			"key": "scaAuthenticationData",
-			"value": "111111",
+			"value": "",
+			"description": "",
+			"enabled": true
+		},
+		{
+			"key": "adapter",
+			"value": "dab-bank",
 			"description": "",
 			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2019-04-18T15:06:05.526Z",
-	"_postman_exported_using": "Postman/6.7.3"
+	"_postman_exported_at": "2019-04-24T10:10:32.087Z",
+	"_postman_exported_using": "Postman/7.0.7"
 }

--- a/postman/xs2a gateway (deutsche-bank).postman_environment.json
+++ b/postman/xs2a gateway (deutsche-bank).postman_environment.json
@@ -1,43 +1,33 @@
 {
-	"id": "09ba1ab0-67a5-4f61-971a-c2057c45b7be",
-	"name": "local xs2a gateway (deutsche-bank)",
+	"id": "fcd068fd-951a-4b4b-9546-2d9fbaed121d",
+	"name": "xs2a gateway (deutsche-bank)",
 	"values": [
-		{
-			"key": "baseUri",
-			"value": "http://localhost:8081",
-			"description": "",
-			"enabled": true
-		},
 		{
 			"key": "bankCode",
 			"value": "50010517",
-			"type": "text",
 			"description": "",
 			"enabled": true
 		},
 		{
 			"key": "psuIdType",
 			"value": "FKDN",
-			"type": "text",
 			"description": "",
 			"enabled": true
 		},
 		{
 			"key": "psuId",
 			"value": "555-EXTAISC-02",
-			"type": "text",
 			"description": "",
 			"enabled": true
 		},
 		{
 			"key": "iban",
 			"value": "DE92500105177545332689",
-			"type": "text",
 			"description": "",
 			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2019-04-17T20:32:55.010Z",
+	"_postman_exported_at": "2019-04-24T10:10:35.128Z",
 	"_postman_exported_using": "Postman/7.0.7"
 }

--- a/postman/xs2a gateway (sparkasse).postman_environment.json
+++ b/postman/xs2a gateway (sparkasse).postman_environment.json
@@ -1,16 +1,10 @@
 {
-	"id": "5602fe8f-eb09-41e2-9f4b-c3b091766e2d",
-	"name": "local xs2a gateway (dab-bank)",
+	"id": "ca5224b0-37b3-4711-adf1-cfc4009014f5",
+	"name": "xs2a gateway (sparkasse)",
 	"values": [
 		{
-			"key": "baseUri",
-			"value": "http://localhost:8081",
-			"description": "",
-			"enabled": true
-		},
-		{
 			"key": "bankCode",
-			"value": "70120400",
+			"value": "99999999",
 			"description": "",
 			"enabled": true
 		},
@@ -22,42 +16,36 @@
 		},
 		{
 			"key": "psuId",
-			"value": "PSU-Successful",
+			"value": "chipTAN",
 			"description": "",
 			"enabled": true
 		},
 		{
 			"key": "iban",
-			"value": "DE74701204003326455007",
+			"value": "DE86999999990000001000",
 			"description": "",
 			"enabled": true
 		},
 		{
 			"key": "password",
-			"value": "",
+			"value": "okok1",
 			"description": "",
 			"enabled": true
 		},
 		{
 			"key": "authenticationMethodId",
-			"value": "",
+			"value": "OPTICAL",
 			"description": "",
 			"enabled": true
 		},
 		{
 			"key": "scaAuthenticationData",
-			"value": "",
-			"description": "",
-			"enabled": true
-		},
-		{
-			"key": "adapter",
-			"value": "dab-bank",
+			"value": "111111",
 			"description": "",
 			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2019-04-24T08:25:45.972Z",
+	"_postman_exported_at": "2019-04-24T10:10:37.340Z",
 	"_postman_exported_using": "Postman/7.0.7"
 }

--- a/postman/xs2a gateway (verlag).postman_environment.json
+++ b/postman/xs2a gateway (verlag).postman_environment.json
@@ -1,16 +1,10 @@
 {
-	"id": "41410be2-b4a5-4929-a781-4a7b6b9f501b",
-	"name": "local xs2a gateway (consors-bank)",
+	"id": "0ef4d111-67dc-4613-ad18-41ab514a8871",
+	"name": "xs2a gateway (verlag)",
 	"values": [
 		{
-			"key": "baseUri",
-			"value": "http://localhost:8081",
-			"description": "",
-			"enabled": true
-		},
-		{
 			"key": "bankCode",
-			"value": "76030080",
+			"value": "25040090",
 			"description": "",
 			"enabled": true
 		},
@@ -22,42 +16,36 @@
 		},
 		{
 			"key": "psuId",
-			"value": "PSU-Successful",
+			"value": "psuId-test",
 			"description": "",
 			"enabled": true
 		},
 		{
 			"key": "iban",
-			"value": "DE60760300800500123456",
+			"value": "DE51250400903312345678",
 			"description": "",
 			"enabled": true
 		},
 		{
 			"key": "password",
-			"value": "",
+			"value": "12456",
 			"description": "",
 			"enabled": true
 		},
 		{
 			"key": "authenticationMethodId",
-			"value": "",
-			"description": "",
+			"value": "901",
+			"description": "SMS-TAN",
 			"enabled": true
 		},
 		{
 			"key": "scaAuthenticationData",
-			"value": "",
-			"description": "",
-			"enabled": true
-		},
-		{
-			"key": "adapter",
-			"value": "consors-bank",
+			"value": "12456",
 			"description": "",
 			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2019-04-24T08:25:42.618Z",
+	"_postman_exported_at": "2019-04-24T10:14:37.764Z",
 	"_postman_exported_using": "Postman/7.0.7"
 }

--- a/postman/xs2a gateway.postman_collection.json
+++ b/postman/xs2a gateway.postman_collection.json
@@ -225,14 +225,14 @@
 					"response": []
 				},
 				{
-					"name": "SCA/Redirect/DAB",
+					"name": "SCA/Redirect/DAB&Consors",
 					"event": [
 						{
 							"listen": "test",
 							"script": {
 								"id": "3620d4f5-d0c3-410c-ae18-a953317608ec",
 								"exec": [
-									"pm.test(\"Body matches string\", function () {",
+									"pm.test(\"Consent status is valid\", function () {",
 									"    pm.expect(pm.response.text()).to.include(\"The consent status has changed to: valid\");",
 									"});",
 									"",


### PR DESCRIPTION
To avoid cross product between number of adapters and gateway environments.